### PR TITLE
Update incorrect statement about Content-Length in res.send documentation

### DIFF
--- a/_includes/api/en/5x/res-send.md
+++ b/_includes/api/en/5x/res-send.md
@@ -14,8 +14,7 @@ res.status(500).send({ error: 'something blew up' })
 ```
 
 This method performs many useful tasks for simple non-streaming responses:
-For example, it automatically assigns the `Content-Length` HTTP response header field
-(unless previously defined) and provides automatic HEAD and HTTP cache freshness support.
+For example, it automatically assigns the `Content-Length` HTTP response header field and provides automatic HEAD and HTTP cache freshness support.
 
 When the parameter is a `Buffer` object, the method sets the `Content-Type`
 response header field  to "application/octet-stream", unless previously defined as shown below:


### PR DESCRIPTION
As per the code, content-length HTTP response header field is automatically assigned even if it is previously defined.

##### Whereas in docs the statement is:
This method performs many useful tasks for simple non-streaming responses: For example, it automatically assigns the Content-Length HTTP response header field **(unless previously defined)** and provides automatic HEAD and HTTP cache freshness support.
